### PR TITLE
Fix typo on IT translation

### DIFF
--- a/translations/it.json
+++ b/translations/it.json
@@ -33,7 +33,7 @@
   "home": {
     "title": "Benvenuti nel Judge Booth!",
     "description": "Il Judge Booth è stato creato per permettere ai giocatori di interagire con gli arbitri come un gruppo di individui che condivide una passione, con cui è divertente passare del tempo insieme e ai quali affidarsi, invece di vederli solo come persone in posizioni di autorità. Il Booth vuole creare un collegamento fra giocatori e arbitri.",
-    "statistiche": "Ci sono {{questions}} domande da {{sets}} set e {{languages}} lingue, scritte da più di {{authors}} autori. Al momento hai selezionato {{filtered}} di queste domande.",
+    "statistics": "Ci sono {{questions}} domande da {{sets}} set e {{languages}} lingue, scritte da più di {{authors}} autori. Al momento hai selezionato {{filtered}} di queste domande.",
     "start": "Mostra le Domande"
   },
   "question": {


### PR DESCRIPTION
There was a typo on `it` translations on `statistics` translation key.

## Expected Result
![schermata 2018-07-13 alle 14 47 59](https://user-images.githubusercontent.com/1499063/42692361-c5045dee-86ab-11e8-8aeb-4040a32239b7.png)



## Actual Result
![schermata 2018-07-13 alle 14 45 09](https://user-images.githubusercontent.com/1499063/42692256-6160d308-86ab-11e8-9075-92b8eabf35c6.png)
